### PR TITLE
fix(documentation): Array items reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ events.docs = {
     event: mongooseToJsonLibraryYouImport(Model) //import your own library, use the 'Model' object in this file.
     'event list': { //this library currently configures the return documentation to look for ``${tag} list`
          type: 'array',
-         schema: { $ref: '#/definitions/event' }
+         items: { $ref: '#/definitions/event' }
        }
    }
 }


### PR DESCRIPTION

### Summary
Error in documentation. The items in an array are defined via a property called items instead of schema.

This resolves (#94)[https://github.com/feathersjs-ecosystem/feathers-swagger/issues/94] for instance.